### PR TITLE
Fixed missing rotation and scale in prefab

### DIFF
--- a/src/rust/WorldData.ts
+++ b/src/rust/WorldData.ts
@@ -104,7 +104,11 @@ export class PrefabData extends Message<PrefabData>  {
 
     @Field.d(3, VectorData)
     public position: VectorData;
+
+    @Field.d(4, VectorData)
     public rotation: VectorData;
+
+    @Field.d(5, VectorData)
     public scale: VectorData;
 }
 


### PR DESCRIPTION
# Bug fix (non-breaking change which fixes an issue)

There is a problem with the prefabs, they aren't getting completely loaded:

Before: 


    @Field.d(3, VectorData)
    public position: VectorData;
    public rotation: VectorData;
    public scale: VectorData;

After:

    @Field.d(3, VectorData)
    public position: VectorData;

    @Field.d(4, VectorData)
    public rotation: VectorData;

    @Field.d(5, VectorData)
    public scale: VectorData;
